### PR TITLE
Logic for parkingzone and parkingspot closes #48 closes #38

### DIFF
--- a/src/main/java/nl/conspect/drivedok/controllers/ParkingZoneController.java
+++ b/src/main/java/nl/conspect/drivedok/controllers/ParkingZoneController.java
@@ -34,7 +34,7 @@ public class ParkingZoneController {
 
     @PostMapping("/create")
     public String saveParkingZone(Model model, ParkingZone parkingZone) {
-        parkingZone = parkingZoneService.initParkingZone(parkingZone);
+        parkingZoneService.initParkingZone(parkingZone);
         model.addAttribute("parkingZone", parkingZone);
         parkingZoneService.create(parkingZone);
         return "parkingzone";

--- a/src/main/java/nl/conspect/drivedok/controllers/ParkingZoneController.java
+++ b/src/main/java/nl/conspect/drivedok/controllers/ParkingZoneController.java
@@ -34,6 +34,7 @@ public class ParkingZoneController {
 
     @PostMapping("/create")
     public String saveParkingZone(Model model, ParkingZone parkingZone) {
+        parkingZone = parkingZoneService.initParkingZone(parkingZone);
         model.addAttribute("parkingZone", parkingZone);
         parkingZoneService.create(parkingZone);
         return "parkingzone";

--- a/src/main/java/nl/conspect/drivedok/model/ParkingSpot.java
+++ b/src/main/java/nl/conspect/drivedok/model/ParkingSpot.java
@@ -44,6 +44,14 @@ public class ParkingSpot {
         this.parkingType = parkingType;
     }
 
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nl/conspect/drivedok/services/ParkingZoneService.java
+++ b/src/main/java/nl/conspect/drivedok/services/ParkingZoneService.java
@@ -49,9 +49,9 @@ public class ParkingZoneService {
 
     /*
      The initParkingZone method defines the default implementation of a ParkingZone.
-     So by default it has certain ParkingSpots.
+     So when the user creates one, it has by default certain ParkingSpots.
      */
-    public ParkingZone initParkingZone(ParkingZone parkingZone){
+    public void initParkingZone(ParkingZone parkingZone){
         ParkingSpot ps1 = new ParkingSpot(ParkingType.DISABLED, 0);
         ParkingSpot ps2 = new ParkingSpot(ParkingType.ELECTRIC, 0);
         ParkingSpot ps3 = new ParkingSpot(ParkingType.NORMAL, parkingZone.getTotalParkingSpots());
@@ -63,7 +63,5 @@ public class ParkingZoneService {
         initSet.add(ps2);
         initSet.add(ps3);
         parkingZone.setParkingSpots(initSet);
-
-        return parkingZone;
     }
 }

--- a/src/main/java/nl/conspect/drivedok/services/ParkingZoneService.java
+++ b/src/main/java/nl/conspect/drivedok/services/ParkingZoneService.java
@@ -1,22 +1,28 @@
 package nl.conspect.drivedok.services;
 
 
+import nl.conspect.drivedok.model.ParkingSpot;
+import nl.conspect.drivedok.model.ParkingType;
 import nl.conspect.drivedok.model.ParkingZone;
 import nl.conspect.drivedok.repositories.ParkingZoneRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @Transactional
 public class ParkingZoneService {
 
     private final ParkingZoneRepository parkingZoneRepository;
+    private  final ParkingSpotService parkingSpotService;
 
-    public ParkingZoneService(ParkingZoneRepository parkingZoneRepository) {
+    public ParkingZoneService(ParkingZoneRepository parkingZoneRepository, ParkingSpotService parkingSpotService) {
         this.parkingZoneRepository = parkingZoneRepository;
+        this.parkingSpotService = parkingSpotService;
     }
 
     public List<ParkingZone> findAll(){
@@ -39,5 +45,25 @@ public class ParkingZoneService {
 
     public void deleteById(Long id){
         parkingZoneRepository.deleteById(id);
+    }
+
+    /*
+     The initParkingZone method defines the default implementation of a ParkingZone.
+     So by default it has certain ParkingSpots.
+     */
+    public ParkingZone initParkingZone(ParkingZone parkingZone){
+        ParkingSpot ps1 = new ParkingSpot(ParkingType.DISABLED, 0);
+        ParkingSpot ps2 = new ParkingSpot(ParkingType.ELECTRIC, 0);
+        ParkingSpot ps3 = new ParkingSpot(ParkingType.NORMAL, parkingZone.getTotalParkingSpots());
+        parkingSpotService.create(ps1);
+        parkingSpotService.create(ps2);
+        parkingSpotService.create(ps3);
+        Set<ParkingSpot>initSet = new HashSet<ParkingSpot>() ;
+        initSet.add(ps1);
+        initSet.add(ps2);
+        initSet.add(ps3);
+        parkingZone.setParkingSpots(initSet);
+
+        return parkingZone;
     }
 }

--- a/src/main/resources/templates/parkingzone.html
+++ b/src/main/resources/templates/parkingzone.html
@@ -14,7 +14,13 @@
     <h2>This is your new DriveDok Zone:</h2>
     <p th:text="|DriveDok Zone: *{name}|">filler text</p>
     <p th:text="|has *{totalParkingSpots} parking spots.|">filler number</p>
-    <button onclick="location.href='/parkingzone/home'">Go to overview</button>
+    <br><br>
+    <div th:each="spot : *{parkingSpots}">
+        <span th:text="${spot.quantity}"></span>
+        <span th:text="| ${spot.parkingType} spots |"></span>
+    </p>
+
 </div>
+    <button onclick="location.href='/parkingzone/home'">Go to overview</button>
 </body>
 </html>

--- a/src/test/java/nl/conspect/drivedok/controllers/ParkingZoneControllerTest.java
+++ b/src/test/java/nl/conspect/drivedok/controllers/ParkingZoneControllerTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,11 +68,13 @@ class ParkingZoneControllerTest {
 
     @Test
     public void shouldCreateParkingZone() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/parkingzone/create", ParkingZone.class)
+
+        mockMvc.perform(post("/parkingzone/create", ParkingZone.class)
                 .param("name", "Zone 1")
                 .param("totalParkingSpots", "100"))
                 .andDo(print())
-                .andExpect(content().string(containsString("Zone 1")));
+                .andExpect(content().string(containsString("Zone 1")))
+        ;
     }
 
     @Test
@@ -91,7 +94,7 @@ class ParkingZoneControllerTest {
     @Test
     public void shouldUpdateParkingZone() throws Exception {
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/parkingzone/update", ParkingZone.class)
+        mockMvc.perform(post("/parkingzone/update", ParkingZone.class)
                 .param("name", "Zone 1")
                 .param("totalParkingSpots", "100"))
                 .andDo(print())

--- a/src/test/java/nl/conspect/drivedok/services/ParkingSpotServiceTest.java
+++ b/src/test/java/nl/conspect/drivedok/services/ParkingSpotServiceTest.java
@@ -82,8 +82,6 @@ class ParkingSpotServiceTest {
         assertEquals(ParkingType.ELECTRIC, afterUpdateSpot.getParkingType());
     }
 
-
-
     @Test
     @DisplayName("Persist 3 ParkingSpots. Delete the second. Expect findAll() to have size 2")
     void deleteById() {

--- a/src/test/java/nl/conspect/drivedok/services/ParkingZoneServiceTest.java
+++ b/src/test/java/nl/conspect/drivedok/services/ParkingZoneServiceTest.java
@@ -18,13 +18,15 @@ import static org.junit.jupiter.api.Assertions.*;
         TestEntityManager testEntityManager;
 
         @Autowired
-        ParkingZoneRepository ParkingZoneRepository;
+        ParkingZoneRepository parkingZoneRepository;
 
-        ParkingZoneService ParkingZoneService;
+        ParkingZoneService parkingZoneService;
+
+        ParkingSpotService parkingSpotService;
 
         @BeforeEach
         public void init() {
-            ParkingZoneService = new ParkingZoneService(ParkingZoneRepository);
+            parkingZoneService = new ParkingZoneService(parkingZoneRepository, parkingSpotService);
         }
 
         @Test
@@ -36,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
             testEntityManager.persist(spot1);
             testEntityManager.persist(spot2);
             testEntityManager.persist(spot3);
-            assertEquals(3, ParkingZoneService.findAll().size());
+            assertEquals(3, parkingZoneService.findAll().size());
         }
 
         @Test
@@ -47,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
             ParkingZone zone2 = new ParkingZone(2L, "Anna", null, 300);
             testEntityManager.persist(zone2);
 
-            String  name = ParkingZoneService.findById(zone1.getId())
+            String  name = parkingZoneService.findById(zone1.getId())
                     .map(ParkingZone::getName)
                     .orElse(null);
             assertEquals("Elsa", name);
@@ -57,11 +59,11 @@ import static org.junit.jupiter.api.Assertions.*;
         @Test
         @DisplayName("Assert initial findAll() to return empty list. Expect subsequent findAll() to be > 0 after create()")
         void create() {
-            assertTrue(ParkingZoneService.findAll().isEmpty());
+            assertTrue(parkingZoneService.findAll().isEmpty());
 
             ParkingZone zone = new ParkingZone(1L, "Elsa", null, 100);
-            ParkingZoneService.create(zone);
-            assertEquals(1, ParkingZoneService.findAll().size());
+            parkingZoneService.create(zone);
+            assertEquals(1, parkingZoneService.findAll().size());
         }
 
         @Test
@@ -70,13 +72,13 @@ import static org.junit.jupiter.api.Assertions.*;
             ParkingZone zone = new ParkingZone(1L, "Elsa", null, 100);
             testEntityManager.persist(zone);
 
-            ParkingZone beforeUpdateZone = ParkingZoneService.findById(zone.getId()).orElse(null);
+            ParkingZone beforeUpdateZone = parkingZoneService.findById(zone.getId()).orElse(null);
             assertNotNull(beforeUpdateZone);
             assertEquals("Elsa", beforeUpdateZone.getName());
 
             beforeUpdateZone.setName("Anna");
-            ParkingZoneService.update(beforeUpdateZone);
-            ParkingZone afterUpdateSpot = ParkingZoneService.findById(zone.getId()).orElse(null);
+            parkingZoneService.update(beforeUpdateZone);
+            ParkingZone afterUpdateSpot = parkingZoneService.findById(zone.getId()).orElse(null);
             assertNotNull(afterUpdateSpot);
             assertEquals("Anna", afterUpdateSpot.getName());
         }
@@ -90,10 +92,10 @@ import static org.junit.jupiter.api.Assertions.*;
             testEntityManager.persist(spot1);
             testEntityManager.persist(spot2);
             testEntityManager.persist(spot3);
-            assertEquals(3, ParkingZoneService.findAll().size());
+            assertEquals(3, parkingZoneService.findAll().size());
 
-            ParkingZoneService.deleteById(spot2.getId());
-            assertEquals(2, ParkingZoneService.findAll().size());
+            parkingZoneService.deleteById(spot2.getId());
+            assertEquals(2, parkingZoneService.findAll().size());
         }
     }
 


### PR DESCRIPTION
Creating a parkingzone now creates by default a parkinzone with three types of parkingspots: DISABLED, ELECTRIC and NORMAL. The current implementation has it so that the totalAmountOfParkingSpots 'goes to' the NORMAL type.

So for example, someone creates "Zone 1" with 500 parkingspots, then the zone will have
parkingtype.DISABLED with 0 spots
parkingtype.ELECTRIC with 0 spots
parkingtype.NORMAL with 500 spots