### PR TITLE
Closes 99: adjust unit tests after adding min size on Licence plate

### DIFF
--- a/src/test/java/nl/conspect/drivedok/services/VehicleServiceTest.java
+++ b/src/test/java/nl/conspect/drivedok/services/VehicleServiceTest.java
@@ -37,7 +37,10 @@ class VehicleServiceTest {
     @Test
     @DisplayName("Create 3 vehicles and persist. Expect findAll() to return a list with size 3")
     void findAll() {
-        final var vehicles = List.of(new Vehicle(), new Vehicle(), new Vehicle());
+        final var vehicles = List.of(
+                new Vehicle("a", "123-456", ParkingType.NORMAL),
+                new Vehicle("b", "123-456", ParkingType.ELECTRIC),
+                new Vehicle("c", "123-456", ParkingType.DISABLED));
         vehicles.forEach(testEntityManager::persist);
         assertEquals(3, vehicleService.findAll().size());
     }
@@ -58,7 +61,7 @@ class VehicleServiceTest {
     @DisplayName("Assert initial findAll() to return empty list. Expect subsequent findAll().size() to be exactly 1 after create()")
     void create() {
         assertTrue(vehicleService.findAll().isEmpty());
-        vehicleService.create(new Vehicle());
+        vehicleService.create(new Vehicle("a", "123-456", ParkingType.NORMAL));
         assertEquals(1, vehicleService.findAll().size());
     }
 


### PR DESCRIPTION
Changed creation of new Vehicles to use the correct constructor, in accordance with new validation annotations introduced in #91